### PR TITLE
[Fix] Move import sync_req into method of sync MiniGram

### DIFF
--- a/src/minigram/main.py
+++ b/src/minigram/main.py
@@ -6,7 +6,7 @@ import time
 from copy import deepcopy
 from typing import Optional, Any
 
-from .request import sync_req, async_req
+from .request import async_req
 
 DEBUG = False
 ALLOWED_UPDATES = [
@@ -250,6 +250,8 @@ class MiniGram(BaseMiniGram):
         return CURRENT_SYNC
 
     def req(self, method: str, **kwargs) -> dict:
+        from .request import sync_req
+        
         if method != "getUpdates" and DEBUG:
             tmp = deepcopy(kwargs)
             tmp["method"] = method

--- a/src/minigram/main.py
+++ b/src/minigram/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib.util
 import json
 import re
 import time
@@ -7,6 +8,10 @@ from copy import deepcopy
 from typing import Optional, Any
 
 from .request import async_req
+
+if not importlib.util.find_spec("aiohttp"):
+    from .request import sync_req
+    
 
 DEBUG = False
 ALLOWED_UPDATES = [
@@ -250,8 +255,6 @@ class MiniGram(BaseMiniGram):
         return CURRENT_SYNC
 
     def req(self, method: str, **kwargs) -> dict:
-        from .request import sync_req
-        
         if method != "getUpdates" and DEBUG:
             tmp = deepcopy(kwargs)
             tmp["method"] = method


### PR DESCRIPTION
As I found quite critical in my case error with imports when in project exists `aiohttp` library. When application tries to import `MiniGramUpdate` it crashes cause can't import sync_req function. I assume there could more elegant solution but at least it won't fail on startup for real working async applications.