### PR TITLE
Fix error import while having aiohttp installed

### DIFF
--- a/src/minigram/request.py
+++ b/src/minigram/request.py
@@ -8,6 +8,20 @@ import urllib.request
 from typing import Dict, Optional, Tuple
 from urllib.parse import urlparse
 
+
+def sync_req(url: str, data: Optional[dict] = None) -> Tuple[int, dict]:
+    headers = {"content-type": "application/json"}
+    try:
+        ssl_context = ssl._create_unverified_context()
+        req = urllib.request.Request(url, data=json.dumps(data).encode("utf-8"), headers=headers)
+        with urllib.request.urlopen(req, timeout=180, context=ssl_context) as response:
+            status_code = response.getcode()
+            response_data = response.read()
+            return status_code, json.loads(response_data.decode("utf-8"))
+    except urllib.error.URLError as e:
+        return int(e.errno) if e.errno else 200, {"result": e.reason}
+
+
 if importlib.util.find_spec("aiohttp"):
     import aiohttp
 
@@ -100,15 +114,3 @@ else:
 
         response_json = json.loads(response_data.decode("utf-8"))
         return status_code, response_json
-
-    def sync_req(url: str, data: Optional[dict] = None) -> Tuple[int, dict]:
-        headers = {"content-type": "application/json"}
-        try:
-            ssl_context = ssl._create_unverified_context()
-            req = urllib.request.Request(url, data=json.dumps(data).encode("utf-8"), headers=headers)
-            with urllib.request.urlopen(req, timeout=180, context=ssl_context) as response:
-                status_code = response.getcode()
-                response_data = response.read()
-                return status_code, json.loads(response_data.decode("utf-8"))
-        except urllib.error.URLError as e:
-            return int(e.errno) if e.errno else 200, {"result": e.reason}


### PR DESCRIPTION
https://github.com/bobuk/minigram-py/pull/6 As it was fixed before the updates

There is minimal setup to reproduce:

(Install venv and activate it, as for me I use uv venv & source .venv/bin/activate)

`uv pip install minigram-py aiohttp`

and in python shell just run this

```
>>> from minigram import MiniGramUpdate
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/user/Projects/check-minigram-import-error/.venv/lib/python3.12/site-packages/minigram/__init__.py", line 3, in <module>
    from .main import MiniGram, MiniGramUpdate, AsyncMiniGram
  File "/Users/user/Projects/check-minigram-import-error/.venv/lib/python3.12/site-packages/minigram/main.py", line 9, in <module>
    from .request import sync_req, async_req
ImportError: cannot import name 'sync_req' from 'minigram.request' (/Users/user/Projects/check-minigram-import-error/.venv/lib/python3.12/site-packages/minigram/request.py). Did you mean: 'async_req'?

```